### PR TITLE
Method reference is recommended in java 8.

### DIFF
--- a/src/AbsDistinct.java
+++ b/src/AbsDistinct.java
@@ -9,6 +9,6 @@ public class AbsDistinct {
 
 	public static int solution(int[] A) {
 
-		return (int) IntStream.of(A).map(e -> Math.abs(e)).distinct().count();
+		return (int) IntStream.of(A).map(Math::abs).distinct().count();
 	}
 }


### PR DESCRIPTION
Wherever possible it is recommended use method reference, hence less verbose code